### PR TITLE
Specifying custom location for config files.

### DIFF
--- a/tbump/config.py
+++ b/tbump/config.py
@@ -175,9 +175,11 @@ def validate_config(cfg: Config) -> None:
         validate_hook_cmd(hook.cmd)
 
 
-def get_config_file(project_path: Path) -> ConfigFile:
+def get_config_file(
+    project_path: Path, specified_config_path: Optional[Path]
+) -> ConfigFile:
     try:
-        res = _get_config_file(project_path)
+        res = _get_config_file(project_path, specified_config_path)
         # Check that the config is valid before returning it,
         # so that problems in config file are reported early
         res.get_config()
@@ -188,8 +190,14 @@ def get_config_file(project_path: Path) -> ConfigFile:
         raise InvalidConfig(parse_error=parse_error)
 
 
-def _get_config_file(project_path: Path) -> ConfigFile:
-    toml_path = project_path / "tbump.toml"
+def _get_config_file(
+    project_path: Path, specified_config_path: Optional[Path]
+) -> ConfigFile:
+    if specified_config_path is not None:
+        toml_path = specified_config_path
+    else:
+        toml_path = project_path / "tbump.toml"
+
     if toml_path.exists():
         doc = tomlkit.loads(toml_path.read_text())
         return TbumpTomlConfig(toml_path, doc)

--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -280,10 +280,14 @@ class FileBumper:
         return ChangeRequest(file.src, current_version, new_version, search=to_search)
 
 
-def bump_files(new_version: str, repo_path: Optional[Path] = None) -> None:
+def bump_files(
+    new_version: str,
+    repo_path: Optional[Path] = None,
+    config_file_path: Optional[Path] = None,
+) -> None:
     repo_path = repo_path or Path(".")
     bumper = FileBumper(repo_path)
-    config_file = tbump.config.get_config_file(repo_path)
+    config_file = tbump.config.get_config_file(repo_path, config_file_path)
     bumper.set_config_file(config_file)
     patches = bumper.get_patches(new_version=new_version)
     n = len(patches)

--- a/tbump/init.py
+++ b/tbump/init.py
@@ -1,6 +1,6 @@
 import textwrap
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import cli_ui as ui
 
@@ -20,7 +20,11 @@ def find_files(working_path: Path, current_version: str) -> List[str]:
 
 
 def init(
-    working_path: Path, *, current_version: str, use_pyproject: bool = False
+    working_path: Path,
+    *,
+    current_version: str,
+    use_pyproject: bool = False,
+    specified_config_path: Optional[Path] = None
 ) -> None:
     """Interactively creates a new tbump.toml"""
     ui.info_1("Generating tbump config file")
@@ -31,7 +35,10 @@ def init(
     else:
         text = ""
         key_prefix = ""
-        cfg_path = working_path / "tbump.toml"
+        if specified_config_path is not None:
+            cfg_path = specified_config_path
+        else:
+            cfg_path = working_path / "tbump.toml"
         if cfg_path.exists():
             ui.fatal(cfg_path, "already exists")
     text += textwrap.dedent(

--- a/tbump/main.py
+++ b/tbump/main.py
@@ -4,10 +4,10 @@ import urllib.parse
 from pathlib import Path
 from typing import List, Optional
 
+import attr
 import cli_ui as ui
 import docopt
 
-import attr
 import tbump
 import tbump.config
 import tbump.git
@@ -31,7 +31,7 @@ Options:
    -h --help          Show this screen.
    -v --version       Show version.
    -C --cwd=<path>    Set working directory to <path>.
-   -c --config=<path> Use specified toml config file. When not set, `tbump.toml` from working directory is assumed.
+   -c --config=<path> Use specified toml config file. When not set, `tbump.toml` is assumed.
    --non-interactive  Never prompt for confirmation. Useful for automated scripts.
    --dry-run          Only display the changes that would be made.
    --only-patch       Only patches files, skipping any git operations or hook commands.

--- a/tbump/test/test_config.py
+++ b/tbump/test/test_config.py
@@ -12,7 +12,7 @@ from tbump.hooks import HOOKS_CLASSES, BeforeCommitHook
 
 
 def test_happy_parse(test_data_path: Path) -> None:
-    config_file = tbump.config.get_config_file(test_data_path)
+    config_file = tbump.config.get_config_file(test_data_path, None)
     config = config_file.get_config()
     foo_json = tbump.config.File(
         src="package.json", search='"version": "{current_version}"'
@@ -47,7 +47,7 @@ def test_uses_pyproject_if_tbump_toml_is_missing(
     test_data_path: Path, tmp_path: Path
 ) -> None:
 
-    expected_file = tbump.config.get_config_file(test_data_path)
+    expected_file = tbump.config.get_config_file(test_data_path, None)
     parsed_config = expected_file.get_parsed()
     tools_config = tomlkit.table()
     tools_config.add("tbump", parsed_config)
@@ -59,7 +59,7 @@ def test_uses_pyproject_if_tbump_toml_is_missing(
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(to_write)
 
-    actual_file = tbump.config.get_config_file(tmp_path)
+    actual_file = tbump.config.get_config_file(tmp_path, None)
     assert actual_file.get_config() == expected_file.get_config()
 
 
@@ -74,7 +74,7 @@ def test_complain_if_pyproject_does_not_contain_tbump_config(tmp_path: Path) -> 
     pyproject_toml.write_text(to_write)
 
     with pytest.raises(tbump.config.ConfigNotFound):
-        tbump.config.get_config_file(tmp_path)
+        tbump.config.get_config_file(tmp_path, None)
 
 
 def test_validate_schema_in_pyrpoject_toml(tmp_path: Path) -> None:
@@ -103,7 +103,7 @@ def test_validate_schema_in_pyrpoject_toml(tmp_path: Path) -> None:
     pyproject_toml.write_text(to_write)
 
     with pytest.raises(tbump.config.InvalidConfig) as e:
-        tbump.config.get_config_file(tmp_path)
+        tbump.config.get_config_file(tmp_path, None)
     assert "'current'" in str(e.value.parse_error)
 
 
@@ -117,7 +117,7 @@ def assert_validation_error(config: Config, expected_message: str) -> None:
 
 @pytest.fixture
 def test_config(test_data_path: Path) -> Config:
-    config_file = tbump.config.get_config_file(test_data_path)
+    config_file = tbump.config.get_config_file(test_data_path, None)
     return config_file.get_config()
 
 

--- a/tbump/test/test_file_bumper.py
+++ b/tbump/test/test_file_bumper.py
@@ -8,7 +8,7 @@ from tbump.test.conftest import file_contains
 
 def test_file_bumper_simple(test_repo: Path) -> None:
     bumper = tbump.file_bumper.FileBumper(test_repo)
-    config_file = tbump.config.get_config_file(test_repo)
+    config_file = tbump.config.get_config_file(test_repo, None)
     assert bumper.working_path == test_repo
     bumper.set_config_file(config_file)
     patches = bumper.get_patches(new_version="1.2.41-alpha-2")
@@ -35,7 +35,7 @@ def test_patcher_preserve_endings(tmp_path: Path) -> None:
 
 def test_file_bumper_preserve_endings(test_repo: Path) -> None:
     bumper = tbump.file_bumper.FileBumper(test_repo)
-    config_file = tbump.config.get_config_file(test_repo)
+    config_file = tbump.config.get_config_file(test_repo, None)
     package_json = test_repo / "package.json"
 
     # Make sure package.json contain CRLF line endings
@@ -83,7 +83,7 @@ def test_looking_for_empty_groups(tmp_path: Path) -> None:
         version = "1.2"
         """
     )
-    config_file = tbump.config.get_config_file(tmp_path)
+    config_file = tbump.config.get_config_file(tmp_path, None)
     bumper = tbump.file_bumper.FileBumper(tmp_path)
     bumper.set_config_file(config_file)
     with pytest.raises(tbump.file_bumper.BadSubstitution) as e:
@@ -110,7 +110,7 @@ def test_current_version_not_found(tmp_path: Path) -> None:
     )
     version_txt_path = tmp_path / "version.txt"
     version_txt_path.write_text("nope")
-    config_file = tbump.config.get_config_file(tmp_path)
+    config_file = tbump.config.get_config_file(tmp_path, None)
 
     bumper = tbump.file_bumper.FileBumper(tmp_path)
     bumper.set_config_file(config_file)
@@ -153,7 +153,7 @@ def test_replacing_with_empty_groups(tmp_path: Path) -> None:
     )
 
     bumper = tbump.file_bumper.FileBumper(tmp_path)
-    config_file = tbump.config.get_config_file(tmp_path)
+    config_file = tbump.config.get_config_file(tmp_path, None)
     bumper.set_config_file(config_file)
     with pytest.raises(tbump.file_bumper.BadSubstitution) as e:
         bumper.get_patches(new_version="1.3")
@@ -200,7 +200,7 @@ def test_changing_same_file_twice(tmp_path: Path) -> None:
         """
     )
     bumper = tbump.file_bumper.FileBumper(tmp_path)
-    config_file = tbump.config.get_config_file(tmp_path)
+    config_file = tbump.config.get_config_file(tmp_path, None)
     bumper.set_config_file(config_file)
     patches = bumper.get_patches(new_version="1.3.0")
     for patch in patches:

--- a/tbump/test/test_git_bumper.py
+++ b/tbump/test/test_git_bumper.py
@@ -10,7 +10,7 @@ from tbump.git_bumper import GitBumper
 
 @pytest.fixture
 def test_git_bumper(test_repo: Path) -> GitBumper:
-    config_file = tbump.config.get_config_file(test_repo)
+    config_file = tbump.config.get_config_file(test_repo, None)
     config = config_file.get_config()
     git_bumper = tbump.git_bumper.GitBumper(
         test_repo, operations=["commit", "tag", "push_commit", "push_tag"]

--- a/tbump/test/test_init.py
+++ b/tbump/test/test_init.py
@@ -21,6 +21,20 @@ def test_creates_tbump_toml_config(test_repo: Path) -> None:
     assert config["version"]["current"] == "1.2.41-alpha1"
 
 
+def test_creates_tbump_toml_config_when_config_path_specified(test_repo: Path) -> None:
+    tbump_path = test_repo / "tbump.toml"
+    tbump_path.unlink()
+    current_version = "1.2.41-alpha1"
+
+    tbump.main.main(
+        ["-C", str(test_repo), "--config", tbump_path, "init", current_version]
+    )
+
+    assert tbump_path.exists()
+    config = tomlkit.loads(tbump_path.read_text())
+    assert config["version"]["current"] == "1.2.41-alpha1"
+
+
 def test_append_to_pyproject(test_repo: Path) -> None:
     cfg_path = test_repo / "pyproject.toml"
     isort_config = textwrap.dedent(

--- a/tbump/test/test_init.py
+++ b/tbump/test/test_init.py
@@ -27,7 +27,7 @@ def test_creates_tbump_toml_config_when_config_path_specified(test_repo: Path) -
     current_version = "1.2.41-alpha1"
 
     tbump.main.main(
-        ["-C", str(test_repo), "--config", tbump_path, "init", current_version]
+        ["-C", str(test_repo), "--config", str(tbump_path), "init", current_version]
     )
 
     assert tbump_path.exists()

--- a/tbump/test/test_main.py
+++ b/tbump/test/test_main.py
@@ -203,6 +203,17 @@ def test_tbump_toml_not_found(
     assert message_recorder.find("No configuration for tbump")
 
 
+def test_tbump_toml_not_found_when_config_specified(
+    test_repo: Path, message_recorder: MessageRecorder
+) -> None:
+    toml_path = test_repo / "non-existing.toml"
+    with pytest.raises(SystemExit):
+        tbump.main.main(
+            ["-C", str(test_repo), "--config", toml_path, "1.2.42", "--non-interactive"]
+        )
+    assert message_recorder.find("No configuration for tbump")
+
+
 def test_tbump_toml_bad_syntax(
     test_repo: Path, message_recorder: MessageRecorder
 ) -> None:

--- a/tbump/test/test_main.py
+++ b/tbump/test/test_main.py
@@ -209,7 +209,14 @@ def test_tbump_toml_not_found_when_config_specified(
     toml_path = test_repo / "non-existing.toml"
     with pytest.raises(SystemExit):
         tbump.main.main(
-            ["-C", str(test_repo), "--config", toml_path, "1.2.42", "--non-interactive"]
+            [
+                "-C",
+                str(test_repo),
+                "--config",
+                str(toml_path),
+                "1.2.42",
+                "--non-interactive",
+            ]
         )
     assert message_recorder.find("No configuration for tbump")
 


### PR DESCRIPTION
Hi,
this is a PR for a feature discussed in #90.
The extra param `--config` is optional and supported in both: regular as well as in `init` mode.