### PR TITLE
add config for field defaults

### DIFF
--- a/tbump/test/project/tbump.toml
+++ b/tbump/test/project/tbump.toml
@@ -12,6 +12,10 @@ regex = '''
     -
     (?P<release>\d+)
   )?
+  (
+    \+
+    (?P<build>[a-z0-9\.]+)
+  )?
   '''
 
 [git]
@@ -32,3 +36,16 @@ version_template = "{major}.{minor}.{patch}"
 [[file]]
 src = "glob*.?"
 search = 'version_[a-z]+ = "{current_version}"'
+
+[[file]]
+src = "version_info.py"
+version_template = '({major}, {minor}, {patch}, "{channel}", {release})'
+search = "version_info = {current_version}"
+
+[[field]]
+name = "channel"
+default = ""
+
+[[field]]
+name = "release"
+default = 0

--- a/tbump/test/project/version_info.py
+++ b/tbump/test/project/version_info.py
@@ -1,0 +1,1 @@
+version_info = (1, 2, 41, "alpha", 1)

--- a/tbump/test/test_main.py
+++ b/tbump/test/test_main.py
@@ -287,7 +287,7 @@ def test_do_not_add_untracked_files(test_repo: Path) -> None:
 def test_bad_substitution(test_repo: Path) -> None:
     toml_path = test_repo / "tbump.toml"
     new_toml = tomlkit.loads(toml_path.read_text())
-    new_toml["file"][0]["version_template"] = "{release}"  # type: ignore
+    new_toml["file"][0]["version_template"] = "{build}"  # type: ignore
     toml_path.write_text(tomlkit.dumps(new_toml))
     run_git(test_repo, "add", ".")
     run_git(test_repo, "commit", "--message", "update repo")


### PR DESCRIPTION
allows a version_template to include fields without a match in the version regex without triggering BadSubstitution.

It's not possible to *omit* fields, which would require a different version template, but they can be empty strings, 0, etc.

This seemed to fit best into how things work for other options, but happy to change names of things, or just close if you don't like how this looks. In particular, I don't know if `field` is the right name for it, but it is what came to mind.

closes #121 