### PR TITLE
Follow-up on the "default fields" feature

### DIFF
--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -170,15 +170,15 @@ class FileBumper:
 
     def parse_version(self, version: str) -> Dict[str, str]:
         assert self.version_regex
-        match = self.version_regex.fullmatch(version)
-        if match is None:
+        regex_match = self.version_regex.fullmatch(version)
+        if regex_match is None:
             raise InvalidVersion(version=version, regex=self.version_regex)
-        groups = match.groupdict()
+        groups = regex_match.groupdict()
 
         # apply default fields from config
         for field in self.fields:
             if groups.get(field.name) is None:
-                groups[field.name] = field.default
+                groups[field.name] = str(field.default)
         return groups
 
     def set_config_file(self, config_file: ConfigFile) -> None:


### PR DESCRIPTION
* [x] Fix mypy error
* [x] Rename 'match' variable (it became a keyword in Python 3.10)
* [x] Update documentation and changelog