### PR TITLE
Fix grep parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Here's what a typical usage of ``tbump`` looks like:
     + tbump.toml:2 current = "5.0.5"
     => Would run these hooks before commit
     * (1/2) $ ./test.sh
-    * (2/2) $ grep -q 5.0.5 Changelog.rst
+    * (2/2) $ grep -q -F 5.0.5 Changelog.rst
     => Would run these git commands
      * git add --update
      * git commit --message Bump to 5.0.5
@@ -228,7 +228,7 @@ Here's an example:
 
     [[before_commit]]
     name = "Check Changelog"
-    cmd = "grep -q {new_version} Changelog.rst"
+    cmd = "grep -q -F {new_version} Changelog.rst"
 
 
 The name is mandatory. The command will be executed via the shell, after the  ``{new_version}``  placeholder is replaced with the new version.


### PR DESCRIPTION
grep uses regex. `.` means "any character", so the check may pass even if the content of the file is wrong

Example:
`2021-11-18:  Release 0.1.0` passes `grep -q 0.1.1` but fails `grep -q -F 0.1.1`.